### PR TITLE
fix page title and description metadata

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -16,15 +16,15 @@ to modify some of the meta-data for the site, this is the place to do it.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Title and meta description
     ================================================== -->
-  <title>{{page.title}}</title>
-  <meta property="og:title" content="{{page.title}}" />
-  <meta name="description" content="{{page.description}}" />
-  <meta property="og:description" content="{{page.description}}" />
+  <title>{{ title }} | {{ site.title }}</title>
+  <meta property="og:title" content="{{title}}" />
+  <meta name="description" content="{{description}}" />
+  <meta property="og:description" content="{{description}}" />
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@{{site.twitter}}" />
-  <meta name="twitter:title" content="{{page.title}}" />
-  <meta name="twitter:description" content="{{page.description}}" />
+  <meta name="twitter:title" content="{{title}}" />
+  <meta name="twitter:description" content="{{description}}" />
 
   <meta property="og:type" content="article" />
   <link rel="canonical" href="{{ page.url }}" />


### PR DESCRIPTION
Titles weren't rendering in the default template